### PR TITLE
Panic in handler now results in 500 error

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,12 @@ To push an event to the bus:
 
 To listen to events published on the bus:
 
-	http.Handle("/", listener.New(func(events []*listener.Event) {
-		fmt.Println(events[0].Topic)
-	}))
+	http.Handle("/", listener.New(
+		"demo",
+		func(events []*listener.Event) {
+			for _, e := range events {
+				log.Printf("%v\n", e)
+			}
+		})
+	))
 	http.ListenAndServeTLS(":8123", "server.crt", "server.key", nil)

--- a/listener.go
+++ b/listener.go
@@ -2,6 +2,7 @@ package routemaster
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 )
@@ -25,25 +26,42 @@ func NewListener(uuid string, handler HandlerFunc) *Listener {
 	}
 }
 
+// error replies to the request with the specified HTTP code, and a simple
+// message based on the code.
+func (l *Listener) error(w http.ResponseWriter, code int) {
+	text := fmt.Sprintf("%d %s", code, http.StatusText(code))
+	http.Error(w, text, code)
+}
+
+// handleEvents runs the handler, catching any panics and returning a 500.
+func (l *Listener) handleEvents(w http.ResponseWriter, events []*Event) {
+	defer func() {
+		if err := recover(); err != nil {
+			l.error(w, http.StatusInternalServerError)
+		}
+	}()
+	l.handler(events)
+}
+
 func (l *Listener) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	username, _, _ := r.BasicAuth()
 	if username != l.uuid {
-		http.Error(w, "", http.StatusUnauthorized)
+		l.error(w, http.StatusUnauthorized)
 		return
 	}
 
 	b, err := ioutil.ReadAll(r.Body)
 	defer r.Body.Close()
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		l.error(w, http.StatusInternalServerError)
 		return
 	}
 
 	var events []*Event
 	err = json.Unmarshal(b, &events)
 	if err != nil || len(events) == 0 {
-		http.Error(w, err.Error(), http.StatusBadRequest)
+		l.error(w, http.StatusBadRequest)
 		return
 	}
-	l.handler(events)
+	l.handleEvents(w, events)
 }


### PR DESCRIPTION
In addition, error messages are now obfuscated; only the name of the HTTP status
code will be returned.