### PR TITLE
models: event data is now json.RawMessage

### DIFF
--- a/models.go
+++ b/models.go
@@ -1,6 +1,7 @@
 package routemaster
 
 import (
+	"encoding/json"
 	"errors"
 	"net/url"
 )
@@ -88,7 +89,7 @@ type ReceivedEvent struct {
 
 	// Data is the payload associated with the event. Optional, and its use
 	// is discouraged.
-	Data interface{} `json:"data,omitempty"`
+	Data json.RawMessage `json:"data"`
 }
 
 // Token represents an API token.


### PR DESCRIPTION
This facilitates easy unmarshalling into either a custom type or an
untyped map.

Addresses #10 